### PR TITLE
Fix using pendingBlock indices on readyBlocks array

### DIFF
--- a/src/Wallet.js
+++ b/src/Wallet.js
@@ -999,7 +999,7 @@ module.exports = function (password) {
   }
 
   api.getReadyBlockByHash = function (blockHash) {
-    for (let i in pendingBlocks) {
+    for (let i in readyBlocks) {
       if (readyBlocks[i].getHash(true) == blockHash) {
         return readyBlocks[i];
       }


### PR DESCRIPTION
A small typo in one of the loops.

@chriscohoat fyi (@jaimehgb knows this already), I'm hacking on Ledger integration. Before the actual Ledger PR, I'll be submitting a bunch of smaller clean up / refactor ones. One of my goals throughout this process is to not break existing public APIs that this library exposes, with the internal code I'm trying to keep the changes to a minimum. So if you do see that my changes are breaking public APIs, do let me know :)