### PR TITLE
Update current pendingBlocks when switching accounts

### DIFF
--- a/src/Wallet.js
+++ b/src/Wallet.js
@@ -388,6 +388,7 @@ module.exports = function (password) {
         lastBlock = keys[i].lastBlock;
         lastPendingBlock = keys[i].lastPendingBlock;
         chain = keys[i].chain;
+        pendingBlocks = keys[i].pendingBlocks;
         representative = keys[i].representative;
         return;
       }


### PR DESCRIPTION
When switching accounts the pendingBlocks variable doesn't get updated with the new account blocks.