### PR TITLE
Restore intended (?) behaviour for getNextWorkBlockHash

### DIFF
--- a/src/Wallet.js
+++ b/src/Wallet.js
@@ -808,14 +808,18 @@ module.exports = function (password) {
   }
 
   api.getNextWorkBlockHash = function (acc) {
-    var aux = currentIdx;
+    var prevAcc = current.account;
     api.useAccount(acc);
 
-    if (current.lastBlock.length > 0)
-      return current.lastBlock;
-    else
-      return uint8_hex(current.pub);
-    api.useAccount(keys[currentIdx].account);
+    let hash;
+    if (current.lastBlock.length > 0) {
+      hash = current.lastBlock;
+    } else {
+      hash = uint8_hex(current.pub);
+    }
+
+    api.useAccount(prevAcc);
+    return hash;
   }
 
   _private.setLastBlockHash = function (blockHash) {


### PR DESCRIPTION
This PR isn't related to the Ledger integration, but I did notice that the getNextWorkBlockHash kind of "attempts" to restore the previous account that was used before it switched away from it. So here's a fix to actually restore the old account.

BUT, a lot of the public APIs switch away from the current account anyway (without attempting to restore previously selected account), so not really sure if this should be fixed, or should just remove the attempt to restore old account completely from the code.