### PR TITLE
Use nano-base32 to simplify account encoding and decoding functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "big-integer": "^1.6.26",
     "blakejs": "^1.1.0",
     "buffer": "^5.0.8",
-    "nano-base32": "^1.0.0",
+    "nano-base32": "1.0.0",
     "pbkdf2": "^3.0.14",
     "tweetnacl": "git+https://git@github.com/jaimehgb/tweetnacl-js.git#ef9ea5fd95c3ca98128877c58e40ef1a711421ef"
   }

--- a/package.json
+++ b/package.json
@@ -24,12 +24,10 @@
     "babel-preset-es2015": "^6.24.1"
   },
   "dependencies": {
-    "array-buffer-to-hex": "^1.0.0",
     "assert": "^1.4.1",
     "big-integer": "^1.6.26",
     "blakejs": "^1.1.0",
     "buffer": "^5.0.8",
-    "hex-to-array-buffer": "^1.1.0",
     "nano-base32": "^1.0.0",
     "pbkdf2": "^3.0.14",
     "tweetnacl": "git+https://git@github.com/jaimehgb/tweetnacl-js.git#ef9ea5fd95c3ca98128877c58e40ef1a711421ef"

--- a/package.json
+++ b/package.json
@@ -24,10 +24,13 @@
     "babel-preset-es2015": "^6.24.1"
   },
   "dependencies": {
+    "array-buffer-to-hex": "^1.0.0",
     "assert": "^1.4.1",
     "big-integer": "^1.6.26",
     "blakejs": "^1.1.0",
     "buffer": "^5.0.8",
+    "hex-to-array-buffer": "^1.1.0",
+    "nano-base32": "^1.0.0",
     "pbkdf2": "^3.0.14",
     "tweetnacl": "git+https://git@github.com/jaimehgb/tweetnacl-js.git#ef9ea5fd95c3ca98128877c58e40ef1a711421ef"
   }

--- a/src/functions.js
+++ b/src/functions.js
@@ -1,6 +1,9 @@
 // general functions
 
 var blake = require('blakejs');
+var nanoBase32 = require('nano-base32')
+var hexToArraryBuffer = require('hex-to-array-buffer')
+var arrayBufferToHex = require('array-buffer-to-hex')
 
 export const stringFromHex = function(hex) {
   var hex = hex.toString();//force conversion
@@ -19,10 +22,10 @@ export const stringToHex = function (str) {
 }
 
 export const accountFromHexKey = function (hex) {
-  var checksum = '';
-  var key_bytes = uint4_uint8(hex_uint4(hex));
-  var checksum = uint5_string(uint4_uint5(uint8_uint4(blake.blake2b(key_bytes, null, 5).reverse())));
-  var c_account = uint5_string(uint4_uint5(hex_uint4('0' + hex)));
+  var key_bytes = new Uint8Array(hexToArraryBuffer(hex))
+  var checksum_bytes = blake.blake2b(key_bytes, null, 5).reverse();
+  var checksum = nanoBase32.encode(checksum_bytes);
+  var c_account = nanoBase32.encode(key_bytes);
   return 'xrb_' + c_account + checksum;
 };
 
@@ -95,139 +98,6 @@ export const hex2dec = function(s) {
   return dec;
 }
 
-
-/*
- BSD 3-Clause License
-
- Copyright (c) 2017, SergiySW
- All rights reserved.
-
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions are met:
-
- * Redistributions of source code must retain the above copyright notice, this
- list of conditions and the following disclaimer.
-
- * Redistributions in binary form must reproduce the above copyright notice,
- this list of conditions and the following disclaimer in the documentation
- and/or other materials provided with the distribution.
-
- * Neither the name of the copyright holder nor the names of its
- contributors may be used to endorse or promote products derived from
- this software without specific prior written permission.
-
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
- FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
- DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
- SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
- */
-
-// Arrays manipulations
-function uint8_uint4(uint8) {
-  var length = uint8.length;
-  var uint4 = new Uint8Array(length * 2);
-  for (let i = 0; i < length; i++) {
-    uint4[i * 2] = uint8[i] / 16 | 0;
-    uint4[i * 2 + 1] = uint8[i] % 16;
-  }
-  return uint4;
-}
-
-function uint4_uint8(uint4) {
-  var length = uint4.length / 2;
-  var uint8 = new Uint8Array(length);
-  for (let i = 0; i < length; i++)  uint8[i] = uint4[i * 2] * 16 + uint4[i * 2 + 1];
-  return uint8;
-}
-
-function uint4_uint5(uint4) {
-  var length = uint4.length / 5 * 4;
-  var uint5 = new Uint8Array(length);
-  for (let i = 1; i <= length; i++) {
-    let n = i - 1;
-    let m = i % 4;
-    let z = n + ((i - m) / 4);
-    let right = uint4[z] << m;
-    let left;
-    if (((length - i) % 4) == 0)  left = uint4[z - 1] << 4;
-    else  left = uint4[z + 1] >> (4 - m);
-    uint5[n] = (left + right) % 32;
-  }
-  return uint5;
-}
-
-function uint5_uint4(uint5) {
-  var length = uint5.length / 4 * 5;
-  var uint4 = new Uint8Array(length);
-  for (let i = 1; i <= length; i++) {
-    let n = i - 1;
-    let m = i % 5;
-    let z = n - ((i - m) / 5);
-    let right = uint5[z - 1] << (5 - m);
-    let left = uint5[z] >> m;
-    uint4[n] = (left + right) % 16;
-  }
-  return uint4;
-}
-
-function string_uint5(string) {
-  var letter_list = letter_list = '13456789abcdefghijkmnopqrstuwxyz'.split('');
-  var length = string.length;
-  var string_array = string.split('');
-  var uint5 = new Uint8Array(length);
-  for (let i = 0; i < length; i++)  uint5[i] = letter_list.indexOf(string_array[i]);
-  return uint5;
-}
-
-function uint5_string(uint5) {
-  var letter_list = letter_list = '13456789abcdefghijkmnopqrstuwxyz'.split('');
-  var string = "";
-  for (let i = 0; i < uint5.length; i++)  string += letter_list[uint5[i]];
-  return string;
-}
-
-export const hex_uint8 = function (hex) {
-  var length = (hex.length / 2) | 0;
-  var uint8 = new Uint8Array(length);
-  for (let i = 0; i < length; i++) uint8[i] = parseInt(hex.substr(i * 2, 2), 16);
-  return uint8;
-}
-
-
-function hex_uint4(hex) {
-  var length = hex.length;
-  var uint4 = new Uint8Array(length);
-  for (let i = 0; i < length; i++) uint4[i] = parseInt(hex.substr(i, 1), 16);
-  return uint4;
-}
-
-
-export const uint8_hex = function (uint8) {
-  var hex = "";
-  let aux;
-  for (let i = 0; i < uint8.length; i++) {
-    aux = uint8[i].toString(16).toUpperCase();
-    if (aux.length == 1)
-      aux = '0' + aux;
-    hex += aux;
-    aux = '';
-  }
-  return (hex);
-}
-
-export const uint4_hex = function (uint4) {
-  var hex = "";
-  for (let i = 0; i < uint4.length; i++) hex += uint4[i].toString(16).toUpperCase();
-  return (hex);
-}
-
 function equal_arrays(array1, array2) {
   for (let i = 0; i < array1.length; i++) {
     if (array1[i] != array2[i])  return false;
@@ -235,26 +105,16 @@ function equal_arrays(array1, array2) {
   return true;
 }
 
-
-function array_crop(array) {
-  var length = array.length - 1;
-  var cropped_array = new Uint8Array(length);
-  for (let i = 0; i < length; i++)
-    cropped_array[i] = array[i + 1];
-  return cropped_array;
-}
-
 export const keyFromAccount = function(account) {
   if ((account.startsWith('xrb_1') || account.startsWith('xrb_3')) && (account.length == 64)) {
     var account_crop = account.substring(4, 64);
     var isValid = /^[13456789abcdefghijkmnopqrstuwxyz]+$/.test(account_crop);
     if (isValid) {
-      var key_uint4 = array_crop(uint5_uint4(string_uint5(account_crop.substring(0, 52))));
-      var hash_uint4 = uint5_uint4(string_uint5(account_crop.substring(52, 60)));
-      var key_array = uint4_uint8(key_uint4);
-      var blake_hash = blake.blake2b(key_array, null, 5).reverse();
-      if (equal_arrays(hash_uint4, uint8_uint4(blake_hash))) {
-        var key = uint4_hex(key_uint4);
+      var key_bytes = nanoBase32.decode(account_crop.substring(0, 52));
+      var hash_bytes = nanoBase32.decode(account_crop.substring(52, 60));
+      var blake_hash = blake.blake2b(key_bytes, null, 5).reverse();
+      if (equal_arrays(hash_bytes, blake_hash)) {
+        var key = arrayBufferToHex(key_bytes).toUpperCase();
         return key;
       }
       else

--- a/src/functions.js
+++ b/src/functions.js
@@ -2,8 +2,6 @@
 
 var blake = require('blakejs');
 var nanoBase32 = require('nano-base32')
-var hexToArraryBuffer = require('hex-to-array-buffer')
-var arrayBufferToHex = require('array-buffer-to-hex')
 
 export const stringFromHex = function(hex) {
   var hex = hex.toString();//force conversion
@@ -22,7 +20,7 @@ export const stringToHex = function (str) {
 }
 
 export const accountFromHexKey = function (hex) {
-  var key_bytes = new Uint8Array(hexToArraryBuffer(hex))
+  var key_bytes = hex_uint8(hex)
   var checksum_bytes = blake.blake2b(key_bytes, null, 5).reverse();
   var checksum = nanoBase32.encode(checksum_bytes);
   var c_account = nanoBase32.encode(key_bytes);
@@ -98,6 +96,32 @@ export const hex2dec = function(s) {
   return dec;
 }
 
+export const hex_uint8 = function (hex) {
+  var length = (hex.length / 2) | 0;
+  var uint8 = new Uint8Array(length);
+  for (let i = 0; i < length; i++) uint8[i] = parseInt(hex.substr(i * 2, 2), 16);
+  return uint8;
+}
+
+export const uint8_hex = function (uint8) {
+  var hex = "";
+  let aux;
+  for (let i = 0; i < uint8.length; i++) {
+    aux = uint8[i].toString(16).toUpperCase();
+    if (aux.length == 1)
+      aux = '0' + aux;
+    hex += aux;
+    aux = '';
+  }
+  return (hex);
+}
+
+export const uint4_hex = function (uint4) {
+  var hex = "";
+  for (let i = 0; i < uint4.length; i++) hex += uint4[i].toString(16).toUpperCase();
+  return (hex);
+}
+
 function equal_arrays(array1, array2) {
   for (let i = 0; i < array1.length; i++) {
     if (array1[i] != array2[i])  return false;
@@ -114,7 +138,7 @@ export const keyFromAccount = function(account) {
       var hash_bytes = nanoBase32.decode(account_crop.substring(52, 60));
       var blake_hash = blake.blake2b(key_bytes, null, 5).reverse();
       if (equal_arrays(hash_bytes, blake_hash)) {
-        var key = arrayBufferToHex(key_bytes).toUpperCase();
+        var key = uint8_hex(key_bytes).toUpperCase();
         return key;
       }
       else

--- a/test.js
+++ b/test.js
@@ -1,0 +1,13 @@
+const { RaiFunctions } = require('./')
+
+const pubKey = '0D7471E5D11FADDCE5315C97B23B464184AFA8C4C396DCF219696B2682D0ADF6'
+const account = 'xrb_15dng9kx49xfumkm4q6qpaxneie6oynebiwpums3ktdd6t3f3dhp69nxgb38'
+
+const derivedAccount = RaiFunctions.accountFromHexKey(pubKey)
+const derivedKey = RaiFunctions.keyFromAccount(account)
+
+console.log(pubKey)
+console.log(derivedKey)
+console.log()
+console.log(account)
+console.log(derivedAccount)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1168,7 +1168,7 @@ nan@^2.3.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
-nano-base32@^1.0.0:
+nano-base32@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/nano-base32/-/nano-base32-1.0.0.tgz#eda445dba06aeb18cff786fdb9fa4f6c5f5c6791"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,6 +49,10 @@ arr-flatten@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
 
+array-buffer-to-hex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-buffer-to-hex/-/array-buffer-to-hex-1.0.0.tgz#9c76e53010ef7bf7bf8a27ebbb41d24e1d83edf4"
+
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
@@ -911,6 +915,10 @@ hawk@3.1.3, hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
+hex-to-array-buffer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/hex-to-array-buffer/-/hex-to-array-buffer-1.1.0.tgz#17cb9613da06c3fefe4bc27436b5bcddf9d309c3"
+
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
@@ -1167,6 +1175,10 @@ ms@2.0.0:
 nan@^2.3.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
+
+nano-base32@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-base32/-/nano-base32-1.0.0.tgz#eda445dba06aeb18cff786fdb9fa4f6c5f5c6791"
 
 node-pre-gyp@^0.6.39:
   version "0.6.39"

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,10 +49,6 @@ arr-flatten@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
 
-array-buffer-to-hex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-buffer-to-hex/-/array-buffer-to-hex-1.0.0.tgz#9c76e53010ef7bf7bf8a27ebbb41d24e1d83edf4"
-
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
@@ -914,10 +910,6 @@ hawk@3.1.3, hawk@~3.1.3:
     cryptiles "2.x.x"
     hoek "2.x.x"
     sntp "1.x.x"
-
-hex-to-array-buffer@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/hex-to-array-buffer/-/hex-to-array-buffer-1.1.0.tgz#17cb9613da06c3fefe4bc27436b5bcddf9d309c3"
 
 hoek@2.x.x:
   version "2.16.3"


### PR DESCRIPTION
I wrote an npm package called [nano-base32](https://github.com/termhn/nano-base32/) which implements the Nano-specific base32 encoding and decoding algorithms. This PR uses it and a couple of very small helper libraries to convert between ArrayBuffers and hex strings to greatly simplify the complexity of the `functions.js` file.

I'll note that as of now this integration is untested since I don't see any test vectors, but I'll write a couple and test them soon...